### PR TITLE
Bugfix and compilation problems on Ubuntu.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,6 +52,7 @@
 			<or>
 				<available file="libpapi.so" filepath="/usr/lib" />
 				<available file="libpapi.so" filepath="/usr/lib64" />
+				<available file="libpapi.so" filepath="/usr/lib/x86_64-linux-gnu" />
 			</or>
 		</and>
 	</condition>
@@ -337,7 +338,7 @@
 			<mapper type="glob" from="*.c" to="*.o" />
 		</apply>
 		<apply
-				executable="gcc"
+				executable="ld"
 				failonerror="true"
 				parallel="true"
 				verbose="true">

--- a/src/java/cz/cuni/mff/d3s/perf/BenchmarkResultsPrinter.java
+++ b/src/java/cz/cuni/mff/d3s/perf/BenchmarkResultsPrinter.java
@@ -62,7 +62,7 @@ public class BenchmarkResultsPrinter {
 		}
 		
 		String format = String.format("%%%dd", columnWidth);
-		for (long[] row : Benchmark.getResults().getData()) {
+		for (long[] row : results.getData()) {
 			for (long r : row) {
 				stream.append(String.format(format, r));
 			}


### PR DESCRIPTION
Fixes a tiny bug in BenchmarkResultsPrinter.
Fixes compilation issues on (probably outdated?) Ubuntu with gcc 4.8 (definitely outdated).