### PR TITLE
Add support for dual loading

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,12 +37,12 @@
 	<property name="barrier.build.dir" location="${build.dir}/barrier/" />
 	<property name="lib.build.dir" location="${build.dir}/lib/" />
 	<property name="javadoc.build.dir" location="${build.dir}/javadoc/" />
-	
+
 	<property name="junit.jar.path" value="lib/junit-4.11.jar" />
 	<property name="hamcrest.jar.path" value="lib/hamcrest-core.jar" />
-	
+
 	<property name="agent.cc" value="gcc" />
-	
+
 	<property name="agent.feature.want.papi" value="true" />
 
 	<antversion property="ant.version.bare" />
@@ -155,6 +155,12 @@
 		location="${agent.build.dir}${file.separator}${agent.filename}" />
 
 
+	<!-- JVM arguments for loading the agent library. -->
+	<property name="agent.jvmarg.agent" value="-agentpath:${agent.path}" />
+	<property name="agent.jvmarg.library" value="-Djava.library.path=${agent.build.dir}" />
+	<property name="agent.jvmarg.default" value="${agent.jvmarg.agent}" />
+
+
 	<!-- Barrier file naming -->
 	<condition property="barrier.filename" value="ubench-barrier">
 		<os family="unix" />
@@ -179,7 +185,7 @@
 		  Then we try ${java.home} that usually points to JRE
 		  that could be inside JDK. After that, we go through
 		  list of typical locations in various distributions.
-		
+
 		  If your distribution uses different location, feel
 		  free to add it here (but preferably only directories
 		  without build versions, such as/usr/java/jdk1.7 but
@@ -390,7 +396,7 @@
 		<echo message="  Java C headers in: ${agent.cc.java.include}" />
 		<echo message="    Used C compiler: ${agent.cc}" />
 		<echo message="C compiler warnings: ${agent.cc.warnings}" />
-		<echo message="shared library name: ${agent.filename}" />
+		<echo message=" Agent library name: ${agent.filename}" />
 		<echo message="       PAPI support: on" if:set="agent.feature.has.papi" />
 		<echo message="       PAPI support: off" unless:set="agent.feature.has.papi" />
 		<echo message="  getrusage support: on" if:set="agent.feature.has.getrusage" />
@@ -411,16 +417,41 @@
 		<antcall target="print-properties" />
 		<antcall target="print-config" />
 		<antcall target="compile" />
+
+		<antcall target="test">
+			<param name="agent.jvmarg" value="${agent.jvmarg.agent}" />
+		</antcall>
+		<antcall target="test">
+			<param name="agent.jvmarg" value="${agent.jvmarg.library}" />
+		</antcall>
+
+		<antcall target="test-junit">
+			<param name="agent.jvmarg" value="${agent.jvmarg.agent}" />
+		</antcall>
+		<antcall target="test-junit">
+			<param name="agent.jvmarg" value="${agent.jvmarg.library}" />
+		</antcall>
+
+		<antcall target="list-events">
+			<param name="agent.jvmarg" value="${agent.jvmarg.agent}" />
+		</antcall>
+		<antcall target="list-events">
+			<param name="agent.jvmarg" value="${agent.jvmarg.library}" />
+		</antcall>
+
+		<antcall target="demo">
+			<param name="agent.jvmarg" value="${agent.jvmarg.agent}" />
+		</antcall>
+		<antcall target="demo">
+			<param name="agent.jvmarg" value="${agent.jvmarg.library}" />
+		</antcall>
+
 		<antcall target="lib" />
-		<antcall target="javadoc" />
 		<antcall target="checkstyle" />
-		<antcall target="test" />
-		<antcall target="test-junit" />
+		<antcall target="javadoc" />
 		<antcall target="dist" />
-		<antcall target="list-events" />
-		<antcall target="demo" />
 	</target>
-	
+
 	<target name="compile"
 		depends="compile-java,compile-agent,compile-barrier"
 		description="Compile everything."
@@ -707,7 +738,8 @@
 		<attribute name="progarg" default="mixed" />
 
 		<sequential>
-			<echo level="info" message="[run] java -agentpath:${agent.path} @{jvmarg} @{classname} @{progarg}" />
+			<fail unless="agent.jvmarg" message="The 'agent.jvmarg' property is not set, cannot load agent library!" />
+			<echo level="info" message="[run] java ${agent.jvmarg} @{jvmarg} @{classname} @{progarg}" />
 			<java
 				classname="@{classname}"
 				fork="true"
@@ -717,7 +749,7 @@
 					<pathelement path="${classes.build.dir}" />
 					<pathelement path="${test.classes.build.dir}" />
 				</classpath>
-				<jvmarg value="-agentpath:${agent.path}" />
+				<jvmarg value="${agent.jvmarg}" />
 				<jvmarg value="@{jvmarg}" />
 				<arg value="@{progarg}" />
 			</java>
@@ -728,6 +760,10 @@
 		depends="compile,compile-test"
 		description="Run simple self-tests (obsoleted)."
 	>
+		<!-- Use default JVM arguments to load the agent (unless overriden from outside). -->
+		<property name="agent.jvmarg" value="${agent.jvmarg.default}" />
+		<echo level="info" message="Agent loaded using ${agent.jvmarg}" />
+
 		<self-test
 			classname="cz.cuni.mff.d3s.perf.CompilationCounterTest"
 			jvmarg="-Xmixed"
@@ -756,6 +792,10 @@
 		depends="compile,compile-test"
 		description="Run JUnit tests, generate HTML report."
 	>
+		<!-- Use default JVM arguments to load the agent (unless overriden from outside). -->
+		<property name="agent.jvmarg" value="${agent.jvmarg.default}" />
+		<echo level="info" message="Agent loaded using ${agent.jvmarg}" />
+
 		<mkdir dir="${test.results.dir}"/>
 		<junit printsummary="no" failureproperty="junit.failed" haltonfailure="no">
 			<classpath>
@@ -767,7 +807,7 @@
 
 			<jvmarg value="-Dubench.classpath=${test.classes.build.dir}${path.separator}${classes.build.dir}" />
 			<jvmarg value="-Dubench.agent=${agent.path}" />
-			<jvmarg value="-Djava.library.path=${agent.build.dir}" />
+			<jvmarg value="${agent.jvmarg}" />
 
 			<assertions>
 				<enable/>
@@ -799,6 +839,10 @@
 		depends="compile,compile-demo"
 		description="Run simple demo (measure md5 speed)."
 	>
+		<!-- Use default JVM arguments to load the agent (unless overriden from outside). -->
+		<property name="agent.jvmarg" value="${agent.jvmarg.default}" />
+		<echo level="info" message="Agent loaded using ${agent.jvmarg}" />
+
 		<java
 			classname="cz.cuni.mff.d3s.perf.demo.MeasureHashing"
 			fork="true"
@@ -808,7 +852,7 @@
 				<pathelement path="${classes.build.dir}" />
 				<pathelement path="${demo.classes.build.dir}" />
 			</classpath>
-			<jvmarg value="-agentpath:${agent.path}" />
+			<jvmarg value="${agent.jvmarg}" />
 			<arg value="build.xml" />
 		</java>
 	</target>
@@ -817,6 +861,10 @@
 		depends="compile-demo"
 		description="List available events."
 	>
+		<!-- Use default JVM arguments to load the agent (unless overriden from outside). -->
+		<property name="agent.jvmarg" value="${agent.jvmarg.default}" />
+		<echo level="info" message="Agent loaded using ${agent.jvmarg}" />
+
 		<java
 			classname="cz.cuni.mff.d3s.perf.demo.ListEvents"
 			fork="true"
@@ -826,7 +874,7 @@
 				<pathelement path="${classes.build.dir}" />
 				<pathelement path="${demo.classes.build.dir}" />
 			</classpath>
-			<jvmarg value="-agentpath:${agent.path}" />
+			<jvmarg value="${agent.jvmarg}" />
 		</java>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -477,6 +477,7 @@
 		<compile-header classname="OverheadEstimations" />
 		<compile-header classname="Measurement" />
 		<compile-header classname="NativeThreads" />
+		<compile-header classname="UbenchAgent" />
 	</target>
 
 	<target name="compile-agent-maybe-gcc" if="agent.cc.is.gcc">

--- a/build.xml
+++ b/build.xml
@@ -132,7 +132,19 @@
 
 	<!-- Agent file naming -->
 	<condition property="agent.filename" value="libubench-agent.so">
-		<os family="unix" />
+		<and>
+			<os family="unix" />
+			<not>
+				<os name="Mac OS X"/>
+			</not>
+		</and>
+	</condition>
+
+	<condition property="agent.filename" value="libubench-agent.jnilib">
+		<and>
+			<os family="unix" />
+			<os name="Mac OS X"/>
+		</and>
 	</condition>
 
 	<condition property="agent.filename" value="ubench-agent.dll">
@@ -378,6 +390,7 @@
 		<echo message="  Java C headers in: ${agent.cc.java.include}" />
 		<echo message="    Used C compiler: ${agent.cc}" />
 		<echo message="C compiler warnings: ${agent.cc.warnings}" />
+		<echo message="shared library name: ${agent.filename}" />
 		<echo message="       PAPI support: on" if:set="agent.feature.has.papi" />
 		<echo message="       PAPI support: off" unless:set="agent.feature.has.papi" />
 		<echo message="  getrusage support: on" if:set="agent.feature.has.getrusage" />

--- a/build.xml
+++ b/build.xml
@@ -754,7 +754,7 @@
 
 			<jvmarg value="-Dubench.classpath=${test.classes.build.dir}${path.separator}${classes.build.dir}" />
 			<jvmarg value="-Dubench.agent=${agent.path}" />
-			<jvmarg value="-agentpath:${agent.path}" />
+			<jvmarg value="-Djava.library.path=${agent.build.dir}" />
 
 			<assertions>
 				<enable/>

--- a/src/c/barrier.c
+++ b/src/c/barrier.c
@@ -18,6 +18,7 @@
 #define _POSIX_C_SOURCE 200809L // For pthreads to include pthread_barrier_t
 
 #include "compiler.h"
+#include "logging.h"
 
 #pragma warning(push, 0)
 /* Ensure compatibility of JNI function types. */
@@ -50,14 +51,14 @@ Java_cz_cuni_mff_d3s_perf_Barrier_initNative(
 	(*jni)->ReleaseStringUTFChars(jni, jname, name);
 	if (shared_mem_id == -1) {
 		// TODO: throw Java exception
-		fprintf(stderr, "Failed to create shared memory segment!\n");
+		ERROR_PRINTF("failed to create shared memory segment!");
 		return;
 	}
 
 	shared_mem_barrier = (pthread_barrier_t*) mmap(0, sizeof(pthread_barrier_t), PROT_READ | PROT_WRITE, MAP_SHARED, shared_mem_id, 0);
 	if (shared_mem_barrier == MAP_FAILED) {
 		// TODO: throw Java exception
-		fprintf(stderr, "Failed to mmap shared memory segment!\n");
+		ERROR_PRINTF("failed to mmap shared memory segment!");
 		return;
 	}
 #else
@@ -65,7 +66,7 @@ Java_cz_cuni_mff_d3s_perf_Barrier_initNative(
 	UNUSED_VARIABLE(jni);
 	UNUSED_VARIABLE(jname);
 
-	fprintf(stderr, "Platform not yet supported.\n");
+	ERROR_PRINTF("platform not yet supported.");
 	return;
 	// TODO: throw Java exception about unsupported platform
 #endif

--- a/src/c/compiler.h
+++ b/src/c/compiler.h
@@ -63,4 +63,20 @@
 #define ONCE while (0)
 #endif
 
+/*
+ * Disable selected MSVC warnings.
+ */
+#ifdef _MSC_VER
+// C4100: unreferenced formal parameter.
+#pragma warning(disable : 4100)
+// C4204: nonstandard extension used: non-constant aggregate initializer.
+#pragma warning(disable : 4204)
+// C4710: function not inlined ('inline' present).
+#pragma warning(disable : 4710)
+// C4711: function selected for automatic inline expansion ('inline' missing).
+#pragma warning(disable : 4711)
+// C4820: padding added after data member.
+#pragma warning(disable : 4820)
+#endif
+
 #endif

--- a/src/c/counter.c
+++ b/src/c/counter.c
@@ -23,49 +23,21 @@
 /* Ensure compatibility of JNI function types. */
 #include "cz_cuni_mff_d3s_perf_CompilationCounter.h"
 
+#include <assert.h>
+#include <stdbool.h>
+
 #include <jni.h>
 #include <jvmti.h>
 #include <jvmticmlr.h>
 #pragma warning(pop)
-
-#define FILL_WITH_ZEROS(variable) memset(&variable, 0, sizeof(variable))
-
-static jvmtiEnv* agent_env;
 
 
 ubench_atomic_int_t counter_compilation = { 0 };
 ubench_atomic_int_t counter_compilation_total = { 0 };
 ubench_atomic_int_t counter_gc_total = { 0 };
 
-static void
-report_error(const char* line_prefix, jvmtiError error, const char* operation_description) {
-	char* error_description = NULL;
-	(void) (*agent_env)->GetErrorName(agent_env, error, &error_description);
-	if (error_description == NULL) {
-		error_description = "uknown error";
-	}
-
-	fprintf(stderr, "%sJVMTI agent error #%d: %s (%s).\n", line_prefix, (int) error, error_description, operation_description);
-}
-
-#define QUOTE2(x) #x
-#define QUOTE(x) QUOTE2(x)
-
-#define REPORT_ERROR(error_number, operation_description) \
-	report_error("[" __FILE__ ":" QUOTE(__LINE__) "]: ", (error_number), (operation_description))
-
-#define REGISTER_EVENT_OR_RETURN(agent_env_var, event) \
-	do { \
-		jvmtiError event_err = (*agent_env_var)->SetEventNotificationMode(agent_env_var, JVMTI_ENABLE, event, NULL); \
-		if (event_err != JVMTI_ERROR_NONE) { \
-			REPORT_ERROR(err, "enabling notification for " #event); \
-			return JNI_ERR; \
-		} \
-	} \
-	ONCE
-
 static void JNICALL
-on_compiled_method_load(
+jvmti_callback_on_compiled_method_load(
 	jvmtiEnv* UNUSED_PARAMETER(jvmti), jmethodID UNUSED_PARAMETER(method),
 	jint UNUSED_PARAMETER(code_size), const void* UNUSED_PARAMETER(code_addr),
 	jint UNUSED_PARAMETER(map_length), const jvmtiAddrLocationMap* UNUSED_PARAMETER(map),
@@ -82,63 +54,29 @@ on_compiled_method_load(
 }
 
 static void JNICALL
-on_gc_finish(jvmtiEnv* UNUSED_PARAMETER(jvmti)) {
+jvmti_callback_on_garbage_collection_finish(jvmtiEnv* UNUSED_PARAMETER(jvmti)) {
 	ubench_atomic_int_inc(&counter_gc_total);
 }
 
-/*
- * Register event handler for JVMTI_EVENT_COMPILED_METHOD_LOAD.
- * We need to enable the capability, set the callback and enable the
- * actual notification.
- */
-static jint
-register_and_enable_callback(void) {
-	jvmtiError err;
+static jvmti_context_t counters_context = {
+	.has_capabilities = true,
+	.capabilities = {
+		.can_generate_compiled_method_load_events = 1,
+		.can_generate_garbage_collection_events = 1,
+	},
+	.callbacks = {
+		.CompiledMethodLoad = &jvmti_callback_on_compiled_method_load,
+		.GarbageCollectionFinish = &jvmti_callback_on_garbage_collection_finish,
+	},
+	.events = { JVMTI_EVENT_COMPILED_METHOD_LOAD, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, 0 }
+};
 
-	jvmtiCapabilities capabilities;
-	FILL_WITH_ZEROS(capabilities);
-	capabilities.can_generate_compiled_method_load_events = 1;
-	capabilities.can_generate_garbage_collection_events = 1;
-	err = (*agent_env)->AddCapabilities(agent_env, &capabilities);
-	if (err != JVMTI_ERROR_NONE) {
-		REPORT_ERROR(err, "adding capabilities to intercept various JVMTI events");
-		return JNI_ERR;
-	}
+//
 
-	jvmtiEventCallbacks callbacks;
-	FILL_WITH_ZEROS(callbacks);
-	callbacks.CompiledMethodLoad = &on_compiled_method_load;
-	callbacks.GarbageCollectionFinish = &on_gc_finish;
-	callbacks.ThreadStart = &ubench_jvm_callback_on_thread_start;
-	callbacks.ThreadEnd = &ubench_jvm_callback_on_thread_end;
-	err = (*agent_env)->SetEventCallbacks(agent_env, &callbacks, sizeof(callbacks));
-	if (err != JVMTI_ERROR_NONE) {
-		REPORT_ERROR(err, "adding callbacks for various JVMTI events");
-		return JNI_ERR;
-	}
-
-
-	REGISTER_EVENT_OR_RETURN(agent_env, JVMTI_EVENT_COMPILED_METHOD_LOAD);
-	REGISTER_EVENT_OR_RETURN(agent_env, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH);
-	REGISTER_EVENT_OR_RETURN(agent_env, JVMTI_EVENT_THREAD_START);
-	REGISTER_EVENT_OR_RETURN(agent_env, JVMTI_EVENT_THREAD_END);
-
-	return JNI_OK;
-}
-
-INTERNAL jint
-ubench_counters_init(jvmtiEnv* jvmti) {
-	DEBUG_PRINTF("initializing counters");
-
-	agent_env = jvmti;
-
-	jint rc;
-	rc = register_and_enable_callback();
-	if (rc != JNI_OK) {
-		return rc;
-	}
-
-	return JNI_OK;
+INTERNAL bool
+ubench_counters_init(JavaVM* jvm) {
+	assert(jvm != NULL);
+	return ubench_jvmti_context_init_and_enable(&counters_context, jvm);
 }
 
 //

--- a/src/c/counter.c
+++ b/src/c/counter.c
@@ -16,6 +16,7 @@
  */
 
 #include "compiler.h"
+#include "jvmutil.h"
 #include "myatomic.h"
 #include "ubench.h"
 

--- a/src/c/events.c
+++ b/src/c/events.c
@@ -58,12 +58,12 @@ typedef struct {
 #define TIMESPEC_TO_NANOS(val) ((val).tv_sec * 1000 * 1000 * 1000 + (val).tv_nsec)
 #define TIMEVAL_TO_MICROS(val) ((val).tv_sec * 1000 * 1000 + (val).tv_usec)
 
-INTERNAL int
+INTERNAL bool
 ubench_event_init(void) {
 #ifdef HAS_QUERY_PERFORMANCE_COUNTER
 	QueryPerformanceFrequency(&windows_timer_frequency);
 #endif
-	return JNI_OK;
+	return true;
 }
 
 #ifdef HAS_TIMESPEC

--- a/src/c/events.c
+++ b/src/c/events.c
@@ -19,7 +19,9 @@
 #define _DEFAULT_SOURCE // For glibc 2.20 to include caddr_t
 #define _POSIX_C_SOURCE 200809L
 
+#include "compiler.h"
 #include "strutil.h"
+#include "myatomic.h"
 #include "ubench.h"
 
 #ifdef HAS_QUERY_PERFORMANCE_COUNTER

--- a/src/c/jvmutil.c
+++ b/src/c/jvmutil.c
@@ -16,8 +16,8 @@
  */
 
 #include "compiler.h"
+#include "jvmutil.h"
 #include "logging.h"
-#include "ubench.h"
 
 #pragma warning(push, 0)
 #include <assert.h>

--- a/src/c/jvmutil.c
+++ b/src/c/jvmutil.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "logging.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)

--- a/src/c/jvmutil.c
+++ b/src/c/jvmutil.c
@@ -1,6 +1,5 @@
 /*
- * Copyright 2014 Charles University in Prague
- * Copyright 2014 Vojtech Horky
+ * Copyright 2023 Charles University in Prague
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/c/jvmutil.c
+++ b/src/c/jvmutil.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "compiler.h"
 #include "logging.h"
 #include "ubench.h"
 

--- a/src/c/jvmutil.c
+++ b/src/c/jvmutil.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 Charles University in Prague
+ * Copyright 2014 Vojtech Horky
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ubench.h"
+
+#pragma warning(push, 0)
+#include <assert.h>
+#include <stdbool.h>
+
+#include <jni.h>
+#include <jvmti.h>
+#pragma warning(pop)
+
+INTERNAL bool
+ubench_jvmti_context_init(jvmti_context_t* context, JavaVM* jvm) {
+	assert(context != NULL && jvm != NULL);
+
+	jvmtiEnv* jvmti;
+
+	// Create a new JVMTI environment and store it in the context if successful.
+	jint env_error = (*jvm)->GetEnv(jvm, (void**) &jvmti, JVMTI_VERSION_1_2);
+	if (env_error != JNI_OK) {
+		DEBUG_PRINTF("failed to get JVMTI environment (error %ld).", (long) env_error);
+		return false;
+	}
+
+	context->jvmti = jvmti;
+	return true;
+}
+
+INTERNAL bool
+ubench_jvmti_context_enable(jvmti_context_t* context) {
+	assert(context != NULL && context->jvmti != NULL);
+
+	jvmtiEnv* jvmti = context->jvmti;
+
+	// Add capabilities required to enable certain events.
+	if (context->has_capabilities) {
+		jvmtiError cap_error = (*jvmti)->AddCapabilities(jvmti, &context->capabilities);
+		if (cap_error != JVMTI_ERROR_NONE) {
+			DEBUG_PRINTF("failed to add capabilities (error %ld).", (long) cap_error);
+			return false;
+		}
+	}
+
+
+	// Enable events first, because we need to do it one by one.
+	// To actually generate events, an event must have a callback.
+	for (int i = 0; context->events[i] != 0; i++) {
+		jvmtiEvent event = context->events[i];
+		jvmtiError event_err = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE, event, NULL);
+		if (event_err != JVMTI_ERROR_NONE) {
+			DEBUG_PRINTF("failed to enable JVMTI event %ld (error %ld).", (long) event, (long) event_err);
+			return false;
+		}
+	}
+
+
+	// Register callbacks last, only after we enable all events.
+	// This is atomic and allows actual events to be generated.
+	jvmtiError cb_error = (*jvmti)->SetEventCallbacks(jvmti, &context->callbacks, sizeof(context->callbacks));
+	if (cb_error != JVMTI_ERROR_NONE) {
+		DEBUG_PRINTF("failed to set event callbacks (error %ld).", (long) cb_error);
+		return false;
+	}
+
+	return true;
+}
+
+INTERNAL bool
+ubench_jvmti_context_init_and_enable(jvmti_context_t* context, JavaVM* jvm) {
+	assert(context != NULL && jvm != NULL);
+
+	if (ubench_jvmti_context_init(context, jvm)) {
+		if (ubench_jvmti_context_enable(context)) {
+			return true;
+		}
+
+		ubench_jvmti_context_destroy(context);
+	}
+
+	return false;
+}
+
+INTERNAL bool
+ubench_jvmti_context_destroy(jvmti_context_t* context) {
+	assert(context != NULL);
+
+	jvmtiEnv* jvmti = context->jvmti;
+	if (jvmti != NULL) {
+		context->jvmti = NULL;
+
+		jvmtiError dispose_error = (*jvmti)->DisposeEnvironment(jvmti);
+		if (dispose_error == JVMTI_ERROR_NONE) {
+			return true;
+		}
+
+		DEBUG_PRINTF("failed to dispose JVMTI environment (error %ld).", (long) dispose_error);
+
+	} else {
+		DEBUG_PRINTF("JVMTI context does not have a valid JVMTI environment.");
+	}
+
+	return false;
+}

--- a/src/c/jvmutil.h
+++ b/src/c/jvmutil.h
@@ -1,6 +1,5 @@
 /*
- * Copyright 2014 Charles University in Prague
- * Copyright 2014 Vojtech Horky
+ * Copyright 2023 Charles University in Prague
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/c/jvmutil.h
+++ b/src/c/jvmutil.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Charles University in Prague
+ * Copyright 2014 Vojtech Horky
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JVMUTIL_H_GUARD
+#define JVMUTIL_H_GUARD
+
+#pragma warning(push, 0)
+#include <stdbool.h>
+
+#include <jni.h>
+#include <jvmti.h>
+#pragma warning(pop)
+
+typedef struct jvmti_context {
+	jvmtiEnv* jvmti;
+
+	bool has_capabilities;
+	jvmtiCapabilities capabilities;
+
+	jvmtiEventCallbacks callbacks;
+
+	// Zero-terminated array of JVMTI events.
+	// The zero element MUST be always present!
+	jvmtiEvent events[];
+} jvmti_context_t;
+
+extern bool ubench_jvmti_context_init(jvmti_context_t*, JavaVM*);
+extern bool ubench_jvmti_context_enable(jvmti_context_t*);
+extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
+extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
+
+#endif
+

--- a/src/c/jvmutil.h
+++ b/src/c/jvmutil.h
@@ -28,14 +28,22 @@
 typedef struct jvmti_context {
 	jvmtiEnv* jvmti;
 
-	bool has_capabilities;
-	jvmtiCapabilities capabilities;
-
 	jvmtiEventCallbacks callbacks;
 
 	// Zero-terminated array of JVMTI events.
 	// The zero element MUST be always present!
-	jvmtiEvent events[];
+	jvmtiEvent events[(JVMTI_MAX_EVENT_TYPE_VAL - JVMTI_MIN_EVENT_TYPE_VAL + 1) + 1];
+
+	bool has_capabilities;
+
+	// Keep this last. When using aggregate initializers, MSVC 19.0 does not
+	// calculate the size of the bitfield properly, which results in the values
+	// of the subsequent fields to be shifted (into the bitfield).
+	//
+	// This is why we also keep a safety pad at the end.
+	jvmtiCapabilities capabilities;
+
+	unsigned long __padding;
 } jvmti_context_t;
 
 extern bool ubench_jvmti_context_init(jvmti_context_t*, JavaVM*);

--- a/src/c/logging.h
+++ b/src/c/logging.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 Charles University in Prague
+ * Copyright 2014 Vojtech Horky
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LOGGING_H_GUARD
+#define LOGGING_H_GUARD
+
+#pragma warning(push, 0)
+#include <stdio.h>
+#pragma warning(pop)
+
+#define UBENCH_PREFIX "[ubench-agent]"
+
+#define LEVEL_PRINTF(level, fmt, ...) fprintf(stderr, UBENCH_PREFIX ": " level "" fmt "\n", ##__VA_ARGS__)
+
+#ifdef UBENCH_DEBUG
+#define DEBUG_PRINTF(fmt, ...) LEVEL_PRINTF("", fmt, ##__VA_ARGS__)
+#else
+#define DEBUG_PRINTF(fmt, ...) (void) 0
+#endif
+
+
+#define WARN_PRINTF(fmt, ...) LEVEL_PRINTF("WARNING: ", fmt, ##__VA_ARGS__)
+#define ERROR_PRINTF(fmt, ...) LEVEL_PRINTF("ERROR: ", fmt, ##__VA_ARGS__)
+#define FATAL_PRINTF(fmt, ...) LEVEL_PRINTF("FATAL: ", fmt, ##__VA_ARGS__)
+
+#endif

--- a/src/c/measure.c
+++ b/src/c/measure.c
@@ -21,6 +21,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "compiler.h"
+#include "logging.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -19,6 +19,7 @@
 #define _DEFAULT_SOURCE // For glibc 2.20 to include caddr_t
 #define _POSIX_C_SOURCE 200809L
 
+#include "logging.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)
@@ -66,8 +67,8 @@ static jint all_eventset_count = 0;
 #ifdef HAS_PAPI
 static void
 __die_with_papi_error(int papi_error, const char* message) {
-	fprintf(
-		stderr, "error: %s: %s (%d)\n",
+	FATAL_PRINTF(
+		"%s: %s (%d), aborting!",
 		message, PAPI_strerror(papi_error), papi_error
 	);
 
@@ -94,7 +95,7 @@ ubench_benchmark_init(void) {
 	// TODO: check for errors
 	int lib_init_rc = PAPI_library_init(PAPI_VER_CURRENT);
 	if (lib_init_rc != PAPI_VER_CURRENT && lib_init_rc > 0) {
-		fprintf(stderr, "error: PAPI library version mismatch!\n");
+		FATAL_PRINTF("PAPI library version mismatch, aborting!");
 		exit(1);
 	}
 
@@ -115,7 +116,7 @@ static void
 do_throw(JNIEnv* jni, const char* message) {
 	jclass exClass = (*jni)->FindClass(jni, "cz/cuni/mff/d3s/perf/MeasurementException");
 	if (exClass == NULL) {
-		fprintf(stderr, "Unable to find MeasurementException class, aborting!\n");
+		FATAL_PRINTF("unable to find 'MeasurementException' class, aborting!");
 		exit(1);
 	}
 	(*jni)->ThrowNew(jni, exClass, message);

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -90,7 +90,7 @@ get_thread_id(void) {
 #endif
 
 INTERNAL bool
-ubench_benchmark_init(void) {
+ubench_measurement_init(void) {
 #ifdef HAS_PAPI
 	// TODO: check for errors
 	int lib_init_rc = PAPI_library_init(PAPI_VER_CURRENT);

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -19,7 +19,9 @@
 #define _DEFAULT_SOURCE // For glibc 2.20 to include caddr_t
 #define _POSIX_C_SOURCE 200809L
 
+#include "compiler.h"
 #include "logging.h"
+#include "myatomic.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -88,7 +88,7 @@ get_thread_id(void) {
 }
 #endif
 
-INTERNAL jint
+INTERNAL bool
 ubench_benchmark_init(void) {
 #ifdef HAS_PAPI
 	// TODO: check for errors
@@ -108,7 +108,7 @@ ubench_benchmark_init(void) {
 
 	ubench_event_init();
 
-	return JNI_OK;
+	return true;
 }
 
 static void

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -107,8 +107,6 @@ ubench_benchmark_init(void) {
 	// PAPI_set_debug(PAPI_VERB_ECONT);
 #endif
 
-	ubench_event_init();
-
 	return true;
 }
 

--- a/src/c/measurement.c
+++ b/src/c/measurement.c
@@ -348,7 +348,7 @@ Java_cz_cuni_mff_d3s_perf_Measurement_createAttachedEventSetWithJavaThread(
 
 #ifdef HAS_PAPI
 	if ((all_eventsets[eventset_index].config.used_backends & UBENCH_EVENT_BACKEND_PAPI) > 0) {
-		native_tid_t native_id = ubench_get_native_thread_id(java_thread_id);
+		native_tid_t native_id = ubench_threads_get_native_id(java_thread_id);
 
 		if (native_id == UBENCH_THREAD_ID_INVALID) {
 			Java_cz_cuni_mff_d3s_perf_Measurement_destroyEventSet(jni, measurement_class, eventset_index);

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -249,6 +249,24 @@ ubench_unregister_native_thread(native_tid_t native_thread_id) {
 
 //
 
+static inline native_tid_t
+ubench_get_current_thread_native_id(void) {
+#if defined(_MSC_VER)
+	return (native_tid_t) GetCurrentThreadId();
+#elif defined(__APPLE__)
+	pthread_t tid = pthread_self();
+	return (native_tid_t) tid;
+#elif defined(__GNUC__)
+	pid_t answer = syscall(__NR_gettid);
+	return (native_tid_t) answer;
+#else
+#error "Threading not supported on this platform."
+	return UBENCH_THREAD_ID_INVALID;
+#endif
+}
+
+//
+
 /*
  * Cached identifier of 'java.lang.Thread.getId()' method.
  * Initialized from the 'VM Init' callback, which is called before the
@@ -330,24 +348,6 @@ static jvmti_context_t threads_context = {
 	},
 	.events = { JVMTI_EVENT_THREAD_START, JVMTI_EVENT_THREAD_END, 0 }
 };
-
-//
-
-INTERNAL native_tid_t
-ubench_get_current_thread_native_id(void) {
-#if defined(_MSC_VER)
-	return (native_tid_t) GetCurrentThreadId();
-#elif defined(__APPLE__)
-	pthread_t tid = pthread_self();
-	return (native_tid_t) tid;
-#elif defined(__GNUC__)
-	pid_t answer = syscall(__NR_gettid);
-	return (native_tid_t) answer;
-#else
-#error "Threading not supported on this platform."
-	return UBENCH_THREAD_ID_INVALID;
-#endif
-}
 
 //
 

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -445,3 +445,12 @@ Java_cz_cuni_mff_d3s_perf_NativeThreads_registerJavaThread(
 	// TODO Consider throwing an exception ('false' really means "already registered").
 	return ubench_register_java_thread(java_thread_id, (native_tid_t) jnative_thread_id);
 }
+
+JNIEXPORT jboolean JNICALL
+Java_cz_cuni_mff_d3s_perf_NativeThreads_registerCurrentJavaThread(
+	JNIEnv* UNUSED_PARAMETER(jni), jclass UNUSED_PARAMETER(threads_class),
+	java_tid_t java_thread_id
+) {
+	// TODO Consider throwing an exception ('false' really means "already registered").
+	return ubench_register_java_thread(java_thread_id, ubench_get_current_thread_native_id());
+}

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -19,7 +19,10 @@
 #define _DEFAULT_SOURCE // For glibc 2.20 to include caddr_t
 #define _POSIX_C_SOURCE 200809L
 
+#include "compiler.h"
 #include "logging.h"
+#include "myatomic.h"
+#include "mylock.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -434,6 +434,8 @@ Java_cz_cuni_mff_d3s_perf_NativeThreads_getNativeId(
 	JNIEnv* UNUSED_PARAMETER(jni), jclass UNUSED_PARAMETER(threads_class),
 	java_tid_t java_thread_id
 ) {
+	DEBUG_PRINTF("NativeThreads.getNativeId(java_thread_id = %" PRId_JAVA_TID ")", java_thread_id);
+
 	native_tid_t native_thread_id = ubench_threads_get_native_id(java_thread_id);
 	if (native_thread_id == UBENCH_THREAD_ID_INVALID) {
 		// TODO Consider throwing an exception (-1 could be a valid id).
@@ -448,6 +450,11 @@ Java_cz_cuni_mff_d3s_perf_NativeThreads_registerJavaThread(
 	JNIEnv* UNUSED_PARAMETER(jni), jclass UNUSED_PARAMETER(threads_class),
 	java_tid_t java_thread_id, java_tid_t jnative_thread_id
 ) {
+	DEBUG_PRINTF(
+		"NativeThreads.registerJavaThread(java_thread_id = %" PRId_JAVA_TID ", jnative_thread_id = %" PRId_JAVA_TID ")",
+		java_thread_id, jnative_thread_id
+	);
+
 	// TODO Consider throwing an exception ('false' really means "already registered").
 	return ubench_register_java_thread(java_thread_id, (native_tid_t) jnative_thread_id);
 }
@@ -457,6 +464,8 @@ Java_cz_cuni_mff_d3s_perf_NativeThreads_registerCurrentJavaThread(
 	JNIEnv* UNUSED_PARAMETER(jni), jclass UNUSED_PARAMETER(threads_class),
 	java_tid_t java_thread_id
 ) {
+	DEBUG_PRINTF("NativeThreads.registerCurrentJavaThread(java_thread_id = %" PRId_JAVA_TID ")", java_thread_id);
+
 	// TODO Consider throwing an exception ('false' really means "already registered").
 	return ubench_register_java_thread(java_thread_id, ubench_get_current_thread_native_id());
 }

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -21,6 +21,7 @@
 
 #include "compiler.h"
 #include "logging.h"
+#include "jvmutil.h"
 #include "myatomic.h"
 #include "mylock.h"
 #include "ubench.h"

--- a/src/c/threads.c
+++ b/src/c/threads.c
@@ -75,10 +75,10 @@ typedef bool (*predicate_func_t)(const void* arg, const thread_map_entry_t* entr
 
 #ifdef UBENCH_DEBUG
 static void
-debug_thread_map_print_entries(const thread_map_t* map) {
+debug_thread_map_print_entries(const thread_map_t* map, const char* prefix) {
 	assert(map != NULL);
 
-	DEBUG_PRINTF("thread_map_t(%p) = {", map);
+	DEBUG_PRINTF("%sthread_map_t(%p) = {", (prefix != NULL) ? prefix : "", map);
 	DEBUG_PRINTF("    .length = %d", map->length);
 	DEBUG_PRINTF("    .capacity = %d", map->capacity);
 
@@ -102,7 +102,7 @@ debug_thread_map_print_entries(const thread_map_t* map) {
 	DEBUG_PRINTF("}");
 }
 #else
-#define debug_thread_map_print_entries(map) (void) 0
+#define debug_thread_map_print_entries(map, prefix) (void) 0
 #endif
 
 //
@@ -230,8 +230,9 @@ static bool
 ubench_register_java_thread(java_tid_t java_thread_id, native_tid_t native_thread_id) {
 	ubench_spinlock_lock(&thread_map_lock);
 
+	debug_thread_map_print_entries(&thread_map, "before adding: ");
 	int result = thread_map_put_java_thread(&thread_map, java_thread_id, native_thread_id);
-	debug_thread_map_print_entries(&thread_map);
+	debug_thread_map_print_entries(&thread_map, "after adding: ");
 
 	ubench_spinlock_unlock(&thread_map_lock);
 
@@ -248,8 +249,9 @@ static bool
 ubench_unregister_native_thread(native_tid_t native_thread_id) {
 	ubench_spinlock_lock(&thread_map_lock);
 
+	debug_thread_map_print_entries(&thread_map, "before removal: ");
 	int result = thread_map_remove_native_thread(&thread_map, native_thread_id);
-	debug_thread_map_print_entries(&thread_map);
+	debug_thread_map_print_entries(&thread_map, "after removal: ");
 
 	ubench_spinlock_unlock(&thread_map_lock);
 	return (result == 0);

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -19,33 +19,148 @@
 #include "ubench.h"
 
 #pragma warning(push, 0)
+#include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 #include <jni.h>
 #include <jvmti.h>
 #pragma warning(pop)
 
-JNIEXPORT jint JNICALL
-Agent_OnLoad(
-	JavaVM* jvm, char* UNUSED_PARAMETER(options), void* UNUSED_PARAMETER(reserved)
+//
+
+static void JNICALL
+jvmti_callback_on_vm_init(
+	jvmtiEnv* UNUSED_PARAMETER(jvmti), JNIEnv* UNUSED_PARAMETER(jni),
+	jthread UNUSED_PARAMETER(thread)
 ) {
+	//
+	// Set the static boolean field 'alreadyLoaded' in the 'UbenchAgent' class to 'true'
+	// to indicate that native methods are already bound, because the library has been
+	// already loaded through the agent mechanism. This will prevent 'UbenchAgent' from
+	// trying to load the library explicitly. Even though the library can handle it, the
+	// 'loadLibrary()' call could fail if the 'java.library.path' is not set correctly.
+	//
+	jclass loader_class = (*jni)->FindClass(jni, "cz/cuni/mff/d3s/perf/UbenchAgent");
+	if (loader_class == NULL) {
+		fprintf(stderr, "warning: could not find 'UbenchAgent' class\n");
+		return;
+	}
+
+	jfieldID field_id = (*jni)->GetStaticFieldID(jni, loader_class, "alreadyLoaded", "Z");
+	if (field_id == NULL) {
+		fprintf(stderr, "warning: could not find 'alreadyLoaded' field in the 'UbenchAgent' class\n");
+		return;
+	}
+
+	(*jni)->SetStaticBooleanField(jni, loader_class, field_id, JNI_TRUE);
+}
+
+static jvmti_context_t init_context = {
+	.callbacks = { .VMInit = &jvmti_callback_on_vm_init },
+	.events = { JVMTI_EVENT_VM_INIT, 0 }
+};
+
+static bool
+ubench_signal_agent_loaded_on_vm_init(JavaVM* jvm) {
+	assert(jvm != NULL);
+	return ubench_jvmti_context_init_and_enable(&init_context, jvm);
+}
+
+//
+
+static bool
+ubench_startup(JavaVM* jvm) {
+	assert(jvm != NULL);
+
+	// Avoid initializing the library twice on startup.
+	static ubench_atomic_int_t startup_guard = { .atomic_value = 0 };
+
+	bool initialized = ubench_atomic_int_inc(&startup_guard) != 0;
+	if (initialized) {
+		DEBUG_PRINTF("ubench already initialized.");
+		return true;
+	}
+
+	//
+	// Initialize the individual modules. Some of them are allowed to fail,
+	// because they will try to use JVMTI which may be unavailable (e.g., in
+	// the native image). This will make some functionality unavailable, but
+	// will still allow using the agent e.g., to use PAPI.
+	//
+	DEBUG_PRINTF("initializing counters module");
 	if (!ubench_counters_init(jvm)) {
-		return JNI_ERR;
+		fprintf(stderr, "warning: failed to initialize event counter module.\n");
 	}
 
+	DEBUG_PRINTF("initializing threads module");
 	if (!ubench_threads_init(jvm)) {
-		return JNI_ERR;
+		fprintf(stderr, "warning: failed to initialize threads module.\n");
 	}
 
+	DEBUG_PRINTF("initializing benchmark module");
 	if (!ubench_benchmark_init()) {
-		return JNI_ERR;
+		fprintf(stderr, "error: failed to initialize benchmark module.\n");
+		return false;
 	}
 
-	DEBUG_PRINTF("initialization completed successfully.");
-	return JNI_OK;
+	// When the VM is initialized, signal that the agent has been loaded.
+	// This will not work in an environment without JVMTI (e.g., native image),
+	// which means that the library must have been loaded explicitly.
+	if (!ubench_signal_agent_loaded_on_vm_init(jvm)) {
+		DEBUG_PRINTF("unable to signal that the agent has been loaded.");
+	}
+
+	return true;
+}
+
+static void
+ubench_shutdown(JavaVM* UNUSED_PARAMETER(jvm)) {
+	assert(jvm != NULL);
+
+	// Avoid finalizing the library twice on shutdown.
+	static ubench_atomic_int_t shutdown_guard = { .atomic_value = 0 };
+
+	bool finalized = ubench_atomic_int_inc(&shutdown_guard) != 0;
+	if (finalized) {
+		DEBUG_PRINTF("ubench already finalized.");
+		return;
+	}
+
+	// So far, there is nothing to do on shutdown.
+	// We do not dispose the JVMTI environments.
+}
+
+//
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* vm, char* UNUSED_PARAMETER(options), void* UNUSED_PARAMETER(reserved)) {
+	DEBUG_PRINTF("agent loading started.");
+	bool success = ubench_startup(vm);
+	DEBUG_PRINTF("agent loading finished (%s).", success ? "success" : "failure");
+	return success ? JNI_OK : JNI_ERR;
 }
 
 JNIEXPORT void JNICALL
-Agent_OnUnload(JavaVM* UNUSED_PARAMETER(jvm)) {
-	DEBUG_PRINTF("agent unloaded.");
+Agent_OnUnload(JavaVM* vm) {
+	DEBUG_PRINTF("agent unloading started.");
+	ubench_shutdown(vm);
+	DEBUG_PRINTF("agent unloading finished.");
+}
+
+//
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM* jvm, void* UNUSED_PARAMETER(reserved)) {
+	DEBUG_PRINTF("library loading started.");
+	bool success = ubench_startup(jvm);
+	DEBUG_PRINTF("library loading finished (%s).", success ? "success" : "failure");
+	return success ? JNI_VERSION_1_8 : 0;
+}
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM* jvm, void* UNUSED_PARAMETER(reserved)) {
+	DEBUG_PRINTF("library unloading started.");
+	ubench_shutdown(jvm);
+	DEBUG_PRINTF("library unloading finished.");
 }

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -17,6 +17,7 @@
 
 #include "compiler.h"
 #include "logging.h"
+#include "myatomic.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -16,12 +16,12 @@
  */
 
 #include "compiler.h"
+#include "logging.h"
 #include "ubench.h"
 
 #pragma warning(push, 0)
 #include <assert.h>
 #include <stdbool.h>
-#include <stdio.h>
 
 #include <jni.h>
 #include <jvmti.h>
@@ -43,13 +43,13 @@ jvmti_callback_on_vm_init(
 	//
 	jclass loader_class = (*jni)->FindClass(jni, "cz/cuni/mff/d3s/perf/UbenchAgent");
 	if (loader_class == NULL) {
-		fprintf(stderr, "warning: could not find 'UbenchAgent' class\n");
+		WARN_PRINTF("could not find 'UbenchAgent' class.");
 		return;
 	}
 
 	jfieldID field_id = (*jni)->GetStaticFieldID(jni, loader_class, "alreadyLoaded", "Z");
 	if (field_id == NULL) {
-		fprintf(stderr, "warning: could not find 'alreadyLoaded' field in the 'UbenchAgent' class\n");
+		WARN_PRINTF("could not find 'alreadyLoaded' field in the 'UbenchAgent' class.");
 		return;
 	}
 
@@ -90,17 +90,17 @@ ubench_startup(JavaVM* jvm) {
 	//
 	DEBUG_PRINTF("initializing counters module");
 	if (!ubench_counters_init(jvm)) {
-		fprintf(stderr, "warning: failed to initialize event counter module.\n");
+		WARN_PRINTF("failed to initialize event counter module.");
 	}
 
 	DEBUG_PRINTF("initializing threads module");
 	if (!ubench_threads_init(jvm)) {
-		fprintf(stderr, "warning: failed to initialize threads module.\n");
+		WARN_PRINTF("failed to initialize threads module.");
 	}
 
 	DEBUG_PRINTF("initializing benchmark module");
 	if (!ubench_benchmark_init()) {
-		fprintf(stderr, "error: failed to initialize benchmark module.\n");
+		ERROR_PRINTF("failed to initialize benchmark module.");
 		return false;
 	}
 

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -59,23 +59,23 @@ ubench_startup(JavaVM* jvm) {
 	// the native image). This will make some functionality unavailable, but
 	// will still allow using the agent e.g., to use PAPI.
 	//
-	DEBUG_PRINTF("initializing counters module");
+	DEBUG_PRINTF("initializing counters module.");
 	if (!ubench_counters_init(jvm)) {
 		WARN_PRINTF("failed to initialize event counter module.");
 	}
 
-	DEBUG_PRINTF("initializing threads module");
+	DEBUG_PRINTF("initializing threads module.");
 	if (!ubench_threads_init(jvm)) {
-		WARN_PRINTF("failed to initialize threads module.");
+		WARN_PRINTF("automatic thread registration not supported.");
 	}
 
-	DEBUG_PRINTF("initializing measurement module");
+	DEBUG_PRINTF("initializing measurement module.");
 	if (!ubench_measurement_init()) {
 		ERROR_PRINTF("failed to initialize measurement module.");
 		return false;
 	}
 
-	DEBUG_PRINTF("initializing event module");
+	DEBUG_PRINTF("initializing event module.");
 	if (!ubench_event_init()) {
 		ERROR_PRINTF("failed to initialize event module.");
 		return false;
@@ -115,7 +115,7 @@ JNIEXPORT jboolean JNICALL
 Java_cz_cuni_mff_d3s_perf_UbenchAgent_nativeIsLoaded(
 	JNIEnv* UNUSED_PARAMETER(jni), jclass UNUSED_PARAMETER(ubench_class)
 ) {
-	DEBUG_PRINTF("nativeIsLoaded called from Java");
+	DEBUG_PRINTF("UBenchAgent.nativeIsLoaded()");
 	return JNI_TRUE;
 }
 

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -104,6 +104,12 @@ ubench_startup(JavaVM* jvm) {
 		return false;
 	}
 
+	DEBUG_PRINTF("initializing event module");
+	if (!ubench_event_init()) {
+		ERROR_PRINTF("failed to initialize event module.");
+		return false;
+	}
+
 	// When the VM is initialized, signal that the agent has been loaded.
 	// This will not work in an environment without JVMTI (e.g., native image),
 	// which means that the library must have been loaded explicitly.

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -98,9 +98,9 @@ ubench_startup(JavaVM* jvm) {
 		WARN_PRINTF("failed to initialize threads module.");
 	}
 
-	DEBUG_PRINTF("initializing benchmark module");
-	if (!ubench_benchmark_init()) {
-		ERROR_PRINTF("failed to initialize benchmark module.");
+	DEBUG_PRINTF("initializing measurement module");
+	if (!ubench_measurement_init()) {
+		ERROR_PRINTF("failed to initialize measurement module.");
 		return false;
 	}
 

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -29,14 +29,11 @@ JNIEXPORT jint JNICALL
 Agent_OnLoad(
 	JavaVM* jvm, char* UNUSED_PARAMETER(options), void* UNUSED_PARAMETER(reserved)
 ) {
-	jint rc;
-
 	if (!ubench_counters_init(jvm)) {
 		return JNI_ERR;
 	}
 
-	rc = ubench_benchmark_init();
-	if (rc != JNI_OK) {
+	if (!ubench_benchmark_init()) {
 		return JNI_ERR;
 	}
 

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -30,17 +30,8 @@ Agent_OnLoad(
 	JavaVM* jvm, char* UNUSED_PARAMETER(options), void* UNUSED_PARAMETER(reserved)
 ) {
 	jint rc;
-	jvmtiEnv* jvmti;
 
-	rc = (*jvm)->GetEnv(jvm, (void**) &jvmti, JVMTI_VERSION);
-	if (rc != JNI_OK) {
-		fprintf(stderr, "Unable to create JVMTI environment, JavaVM->GetEnv failed, error %ld.\n", (long) rc);
-		return JNI_ERR;
-	}
-
-	rc = ubench_counters_init(jvmti);
-
-	if (rc != JNI_OK) {
+	if (!ubench_counters_init(jvm)) {
 		return JNI_ERR;
 	}
 

--- a/src/c/ubench.c
+++ b/src/c/ubench.c
@@ -33,6 +33,10 @@ Agent_OnLoad(
 		return JNI_ERR;
 	}
 
+	if (!ubench_threads_init(jvm)) {
+		return JNI_ERR;
+	}
+
 	if (!ubench_benchmark_init()) {
 		return JNI_ERR;
 	}

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -101,7 +101,7 @@ typedef int_fast64_t native_tid_t;
 #define UBENCH_SNAPSHOT_TYPE_START (-1)
 #define UBENCH_SNAPSHOT_TYPE_END (-2)
 
-typedef struct {
+typedef struct ubench_events_snapshot {
 	timestamp_t timestamp;
 	threadtime_t threadtime;
 #ifdef HAS_GETRUSAGE
@@ -132,7 +132,7 @@ struct ubench_event_info {
 	char* name;
 };
 
-typedef struct {
+typedef struct benchmark_configuration {
 	unsigned int used_backends;
 
 	ubench_event_info_t* used_events;
@@ -150,7 +150,7 @@ typedef struct {
 	size_t data_index;
 } benchmark_configuration_t;
 
-typedef struct {
+typedef struct jvmti_context {
 	jvmtiEnv* jvmti;
 
 	bool has_capabilities;

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -177,13 +177,10 @@ extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 
 extern bool ubench_counters_init(JavaVM*);
 
-extern void ubench_register_this_thread(jthread, JNIEnv*);
-extern void ubench_unregister_this_thread(jthread, JNIEnv*);
-extern int ubench_register_thread_id_mapping(java_tid_t, native_tid_t);
-extern int ubench_unregister_thread_id_mapping_by_native_id(native_tid_t);
-extern native_tid_t ubench_get_native_thread_id(java_tid_t);
+extern native_tid_t ubench_threads_get_native_id(java_tid_t);
 extern native_tid_t ubench_get_current_thread_native_id(void);
 extern jint ubench_benchmark_init(void);
+
 extern int ubench_event_init(void);
 extern int ubench_event_resolve(const char*, ubench_event_info_t*);
 extern void ubench_event_iterate(event_info_iterator_callback_t, void*);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -33,12 +33,6 @@
 #include <jvmti.h>
 #pragma warning(pop)
 
-#ifdef UBENCH_DEBUG
-#define DEBUG_PRINTF(fmt, ...) printf("[ubench-agent]: " fmt "\n", ##__VA_ARGS__)
-#else
-#define DEBUG_PRINTF(fmt, ...) (void) 0
-#endif
-
 #ifdef HAS_GETRUSAGE
 #include <sys/resource.h>
 #endif

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -175,10 +175,8 @@ extern bool ubench_jvmti_context_enable(jvmti_context_t*);
 extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
 extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 
-extern void ubench_jvm_callback_on_thread_start(jvmtiEnv*, JNIEnv*, jthread);
-extern void ubench_jvm_callback_on_thread_end(jvmtiEnv*, JNIEnv*, jthread);
+extern bool ubench_counters_init(JavaVM*);
 
-extern jint ubench_counters_init(jvmtiEnv*);
 extern void ubench_register_this_thread(jthread, JNIEnv*);
 extern void ubench_unregister_this_thread(jthread, JNIEnv*);
 extern int ubench_register_thread_id_mapping(java_tid_t, native_tid_t);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -175,7 +175,7 @@ extern bool ubench_benchmark_init(void);
 extern bool ubench_threads_init(JavaVM*);
 extern native_tid_t ubench_threads_get_native_id(java_tid_t);
 
-extern int ubench_event_init(void);
+extern bool ubench_event_init(void);
 extern int ubench_event_resolve(const char*, ubench_event_info_t*);
 extern void ubench_event_iterate(event_info_iterator_callback_t, void*);
 

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -150,24 +150,6 @@ typedef struct benchmark_configuration {
 	size_t data_index;
 } benchmark_configuration_t;
 
-typedef struct jvmti_context {
-	jvmtiEnv* jvmti;
-
-	bool has_capabilities;
-	jvmtiCapabilities capabilities;
-
-	jvmtiEventCallbacks callbacks;
-
-	// Zero-terminated array of JVMTI events.
-	// The zero element MUST be always present!
-	jvmtiEvent events[];
-} jvmti_context_t;
-
-extern bool ubench_jvmti_context_init(jvmti_context_t*, JavaVM*);
-extern bool ubench_jvmti_context_enable(jvmti_context_t*);
-extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
-extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
-
 extern bool ubench_counters_init(JavaVM*);
 extern bool ubench_measurement_init(void);
 

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -180,7 +180,6 @@ extern bool ubench_benchmark_init(void);
 
 extern bool ubench_threads_init(JavaVM*);
 extern native_tid_t ubench_threads_get_native_id(java_tid_t);
-extern native_tid_t ubench_get_current_thread_native_id(void);
 
 extern int ubench_event_init(void);
 extern int ubench_event_resolve(const char*, ubench_event_info_t*);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -170,7 +170,7 @@ extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
 extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 
 extern bool ubench_counters_init(JavaVM*);
-extern bool ubench_benchmark_init(void);
+extern bool ubench_measurement_init(void);
 
 extern bool ubench_threads_init(JavaVM*);
 extern native_tid_t ubench_threads_get_native_id(java_tid_t);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -176,10 +176,10 @@ extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
 extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 
 extern bool ubench_counters_init(JavaVM*);
+extern bool ubench_benchmark_init(void);
 
 extern native_tid_t ubench_threads_get_native_id(java_tid_t);
 extern native_tid_t ubench_get_current_thread_native_id(void);
-extern jint ubench_benchmark_init(void);
 
 extern int ubench_event_init(void);
 extern int ubench_event_resolve(const char*, ubench_event_info_t*);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -24,6 +24,7 @@
 
 #pragma warning(push, 0)
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -155,6 +156,24 @@ typedef struct {
 	size_t data_size;
 	size_t data_index;
 } benchmark_configuration_t;
+
+typedef struct {
+	jvmtiEnv* jvmti;
+
+	bool has_capabilities;
+	jvmtiCapabilities capabilities;
+
+	jvmtiEventCallbacks callbacks;
+
+	// Zero-terminated array of JVMTI events.
+	// The zero element MUST be always present!
+	jvmtiEvent events[];
+} jvmti_context_t;
+
+extern bool ubench_jvmti_context_init(jvmti_context_t*, JavaVM*);
+extern bool ubench_jvmti_context_enable(jvmti_context_t*);
+extern bool ubench_jvmti_context_destroy(jvmti_context_t*);
+extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 
 extern void ubench_jvm_callback_on_thread_start(jvmtiEnv*, JNIEnv*, jthread);
 extern void ubench_jvm_callback_on_thread_end(jvmtiEnv*, JNIEnv*, jthread);

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -20,7 +20,6 @@
 
 #include "compiler.h"
 #include "myatomic.h"
-#include "mylock.h"
 
 #pragma warning(push, 0)
 #include <inttypes.h>

--- a/src/c/ubench.h
+++ b/src/c/ubench.h
@@ -178,6 +178,7 @@ extern bool ubench_jvmti_context_init_and_enable(jvmti_context_t*, JavaVM*);
 extern bool ubench_counters_init(JavaVM*);
 extern bool ubench_benchmark_init(void);
 
+extern bool ubench_threads_init(JavaVM*);
 extern native_tid_t ubench_threads_get_native_id(java_tid_t);
 extern native_tid_t ubench_get_current_thread_native_id(void);
 

--- a/src/java/cz/cuni/mff/d3s/perf/Barrier.java
+++ b/src/java/cz/cuni/mff/d3s/perf/Barrier.java
@@ -19,6 +19,11 @@ package cz.cuni.mff.d3s.perf;
 
 /** Process-wide barrier, Linux only now. */
 public final class Barrier {
+
+    static {
+        UbenchAgent.load();
+    }
+
     /** Prevent instantiation. */
     private Barrier() {}
 

--- a/src/java/cz/cuni/mff/d3s/perf/CompilationCounter.java
+++ b/src/java/cz/cuni/mff/d3s/perf/CompilationCounter.java
@@ -19,6 +19,11 @@ package cz.cuni.mff.d3s.perf;
 
 /** Provides access to number of JIT compilations. */
 public final class CompilationCounter {
+
+    static {
+        UbenchAgent.load();
+    }
+
     /** Prevent instantiation. */
     private CompilationCounter() {}
 

--- a/src/java/cz/cuni/mff/d3s/perf/Measurement.java
+++ b/src/java/cz/cuni/mff/d3s/perf/Measurement.java
@@ -34,7 +34,11 @@ public final class Measurement {
 
     /** Generics' helper. */
     private static final String[] STRING_ARRAY_TYPE = new String[0];
-    
+
+    static {
+        UbenchAgent.load();
+    }
+
     /** Prevent instantiation. */
     private Measurement() {}
 

--- a/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
+++ b/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
@@ -70,4 +70,19 @@ public final class NativeThreads {
      * @return Whether registration was successful.
      */
     private static native boolean registerJavaThread(long javaThreadId, long nativeId);
+
+    /** Insert a mapping between the current Java thread and its native id.
+     *
+     * @return Whether registration was successful.
+     */
+    public static boolean registerCurrentJavaThread() {
+        return registerCurrentJavaThread(Thread.currentThread ().getId());
+    }
+
+    /** Insert a mapping between the current Java thread and its native id.
+     *
+     * @param javaThreadId Java thread id of the current thread.
+     * @return Whether registration was successful.
+     */
+    private static native boolean registerCurrentJavaThread(long javaThreadId);
 }

--- a/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
+++ b/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
@@ -23,7 +23,11 @@ import java.util.NoSuchElementException;
 public final class NativeThreads {
     /** Invalid thread ID marker. */
     private static final long INVALID_THREAD_ID = -1;
-    
+
+    static {
+        UbenchAgent.load();
+    }
+
     /** Prevent instantiation. */
     private NativeThreads() {}
 

--- a/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
+++ b/src/java/cz/cuni/mff/d3s/perf/NativeThreads.java
@@ -76,7 +76,7 @@ public final class NativeThreads {
      * @return Whether registration was successful.
      */
     public static boolean registerCurrentJavaThread() {
-        return registerCurrentJavaThread(Thread.currentThread ().getId());
+        return registerCurrentJavaThread(Thread.currentThread().getId());
     }
 
     /** Insert a mapping between the current Java thread and its native id.

--- a/src/java/cz/cuni/mff/d3s/perf/OverheadEstimations.java
+++ b/src/java/cz/cuni/mff/d3s/perf/OverheadEstimations.java
@@ -19,6 +19,11 @@ package cz.cuni.mff.d3s.perf;
 
 /** Helper class for estimating overhead of native calls. */
 public final class OverheadEstimations {
+
+    static {
+        UbenchAgent.load();
+    }
+
     /** Prevent instantiation. */
     private OverheadEstimations() {}
 

--- a/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
+++ b/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
@@ -1,0 +1,11 @@
+package cz.cuni.mff.d3s.perf;
+
+final class UbenchAgent {
+    volatile static boolean alreadyLoaded = false;
+
+    static void load() {
+        if (!alreadyLoaded) {
+            System.loadLibrary("ubench-agent");
+        }
+    }
+}

--- a/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
+++ b/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
@@ -1,11 +1,28 @@
 package cz.cuni.mff.d3s.perf;
 
 final class UbenchAgent {
-    volatile static boolean alreadyLoaded = false;
-
+    
     static void load() {
-        if (!alreadyLoaded) {
+        // Load the agent library if not already loaded.
+        if (!isLoaded()) {
             System.loadLibrary("ubench-agent");
         }
     }
+    
+    private static boolean isLoaded() {
+        //
+        // Try calling a harmless native method in the agent. If the call
+        // succeeds, it means that the library has been already loaded and
+        // its native methods were bound. If it fails, the library needs to
+        // be loaded explicitly.
+        //
+        try {
+            return nativeIsLoaded();
+        } catch (final UnsatisfiedLinkError e) {
+            return false;
+        }
+    }
+    
+    private native static boolean nativeIsLoaded();
+    
 }

--- a/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
+++ b/src/java/cz/cuni/mff/d3s/perf/UbenchAgent.java
@@ -1,14 +1,25 @@
 package cz.cuni.mff.d3s.perf;
 
+/**
+ * Agent library loader. Allows loading the 'ubench-agent' library explicitly 
+ * using {@link System#loadLibrary()} (if not loaded as native agent).
+ */
 final class UbenchAgent {
     
+    /** Prevent instantiation. */
+    private UbenchAgent() {}
+    
+    /** Loads the agent library (if not already loaded). */
     static void load() {
-        // Load the agent library if not already loaded.
         if (!isLoaded()) {
             System.loadLibrary("ubench-agent");
         }
     }
     
+    /** Determines if the agent library is loaded. 
+     * 
+     * @return {@code true} if the native library is loaded, {@code false} otherwise.
+     */
     private static boolean isLoaded() {
         //
         // Try calling a harmless native method in the agent. If the call
@@ -23,6 +34,11 @@ final class UbenchAgent {
         }
     }
     
-    private native static boolean nativeIsLoaded();
+    /** Utility method to determine if the agent library is loaded. 
+     * 
+     * @return {@code true} if the native library is loaded.
+     * @throws UnsatisfiedLinkError if the native library is not loaded.
+     */
+    private static native boolean nativeIsLoaded();
     
 }


### PR DESCRIPTION
Allows loading the agent library either as a JVM agent or as a normal native library.

Includes several refactorings that "just happened". These include changes to make initialization more straightforward, but also changes that split off bits from the single `ubench.h` include file.

This is supposed to be merged on top of #11.