### PR TITLE
Update checkstyle version and slightly tweak configuration

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -868,7 +868,7 @@
 	</target>
 
 	<target name="checkstyle">
-		<java jar="lib/checkstyle-8.10-all.jar" fork="true">
+		<java jar="lib/checkstyle-9.3-all.jar" fork="true">
 			<arg value="-c" />
 			<arg file="checkstyle.xml" />
 			<arg file="src/java" />

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -17,13 +17,16 @@
     <property name="header" value="Licensed under the Apache License" />
     <property name="multiLines" value="1,2,3,4,5,6" />
   </module>
-  <module name="JavadocPackage">
+  <module name="JavadocPackage" />
+  <module name="NewlineAtEndOfFile" />
+  <module name="LineLength">
+    <property name="fileExtensions" value="java" />
+    <property name="max" value="100" />
   </module>
-  <module name="NewlineAtEndOfFile">
-</module>
   <module name="FileLength">
     <property name="max" value="500" />
   </module>
+
   <module name="TreeWalker">
     <module name="AnnotationLocation">
       <property name="allowSamelineSingleParameterlessAnnotation" value="false" />
@@ -93,10 +96,19 @@
     <module name="UnnecessaryParentheses" />
     <module name="VariableDeclarationUsageDistance" />
     <module name="AvoidStarImport" />
-    <module name="AvoidStaticImport" />
-    <module name="CustomImportOrder" />
+    <module name="AvoidStaticImport">
+      <property name="excludes" value="java.util.stream.Collectors.*" />
+    </module>
+    <module name="CustomImportOrder">
+      <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE" />
+    </module>
     <module name="IllegalImport" />
-    <module name="ImportOrder" />
+    <module name="ImportOrder">
+      <property name="ordered" value="true" />
+      <property name="separated" value="true" />
+      <property name="option" value="top" />
+      <property name="separatedStaticGroups" value="true" />
+    </module>
     <module name="RedundantImport" />
     <module name="UnusedImports" />
     <module name="AtclauseOrder" />
@@ -150,9 +162,6 @@
     <module name="TypeName" />
     <module name="AnonInnerLength" />
     <module name="ExecutableStatementCount" />
-    <module name="LineLength">
-      <property name="max" value="100" />
-    </module>
     <module name="MethodCount">
       <property name="maxTotal" value="50" />
     </module>
@@ -173,7 +182,14 @@
     </module>
     <module name="OperatorWrap" />
     <module name="ParenPad" />
-    <module name="SeparatorWrap" />
+    <module name="SeparatorWrap">
+      <property name="option" value="eol" />
+      <property name="tokens" value="COMMA" />
+    </module>
+    <module name="SeparatorWrap">
+      <property name="option" value="nl" />
+      <property name="tokens" value="DOT" />
+    </module>
     <module name="SingleSpaceSeparator" />
     <module name="TypecastParenPad" />
     <module name="WhitespaceAfter" />

--- a/src/java/cz/cuni/mff/d3s/perf/Measurement.java
+++ b/src/java/cz/cuni/mff/d3s/perf/Measurement.java
@@ -41,7 +41,8 @@ public final class Measurement {
     /** Create new event set.
      *
      * @param measurementCount How many measurements should the C agent remember.
-     * @param events An array of event names (use {@link #getSupportedEvents()} to get supported event names).
+     * @param events An array of event names (use {@link #getSupportedEvents()} to get
+     *     supported event names).
      * @param options Extra options (flags).
      * @return Event set number (opaque identifier).
      * @throws cz.cuni.mff.d3s.perf.MeasurementException On any failure when setting-up


### PR DESCRIPTION
This updates checkstyle to newer version that supports reasonable ordering of static imports. This is intended to allow #12 to pass checkstyle tests, but other than that, this change is completely independent. 